### PR TITLE
Update application.conf - Configuración de cookies

### DIFF
--- a/web/conf/application.conf
+++ b/web/conf/application.conf
@@ -45,9 +45,10 @@ date.format=yyyy-MM-dd
 # By default, session will be written to the transient PLAY_SESSION cookie.
 # The cookies are not secured by default, only set it to true
 # if you're serving your pages through https.
-# application.session.cookie=PLAY
-# application.session.maxAge=1h
-# application.session.secure=false
+application.session.cookie=PLAY
+application.session.maxAge=1h
+application.session.secure=true
+application.session.httponly=true
 
 # Session/Cookie sharing between subdomain
 # ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Configuro una cookie de sesión con una validez de 1 hora, sólo válida para conexiones encriptadas y accesible sólo para los protocolos http y https

application.session.cookie=PLAY
application.session.maxAge=1h
application.session.secure=true
application.session.httponly=true

Con esto se solucionaría la vulnerabilidad señalada por José Miguel Corrochano Arévalo:
"En los parámetros de la cookie de sesion llamada PLAY_SESSION no esta habilitado el flag secure que nos verifica que la conexion con el servidor esta cifrada y el flag httponly que impide que la cookie se pueda modificar desde el lado del cliente. Tampoco tiene configurada una fecha de expirado"