### PR TITLE
Update application.conf - Cambio de modo developer

### DIFF
--- a/web/conf/application.conf
+++ b/web/conf/application.conf
@@ -6,7 +6,7 @@ application.name=master-ciberseguridad
 # ~~~~~
 # Set to dev to enable instant reloading and other development help.
 # Otherwise set to prod.
-application.mode=dev
+application.mode=prod
 %prod.application.mode=prod
 
 # Secret key
@@ -233,8 +233,8 @@ mail.smtp=mock
 # Testing. Set up a custom configuration for test mode
 # ~~~~~
 #%test.module.cobertura=${play.path}/modules/cobertura
-%test.application.mode=dev
-%test.db.url=jdbc:h2:mem:play;MODE=MYSQL;LOCK_MODE=0
-%test.jpa.ddl=create
-%test.mail.smtp=mock
+#%test.application.mode=dev
+#%test.db.url=jdbc:h2:mem:play;MODE=MYSQL;LOCK_MODE=0
+#%test.jpa.ddl=create
+#%test.mail.smtp=mock
 


### PR DESCRIPTION
He procedido a cambiar el modo de ejecución "dev" (Developer" por el modo de ejecución "prod" (Producción), suponiendo que está ya todo OK y que vamos a poner la app en producción.

Muchos fallos de seguridad vienen por "dejar olvidadas" en las aplicaciones puertas usadas para el desarrollo del sistema que luego no se eliminan.