### PR TITLE
Evitar Login Sin poner usuario - NO FUNCIONA

### DIFF
--- a/web/app/controllers/Application.java
+++ b/web/app/controllers/Application.java
@@ -32,12 +32,18 @@ public class Application extends Controller {
         checkUser();
 
         User u = (User) renderArgs.get("user");
-
-        if (u.getType().equals(Constants.User.TEACHER)){
-            List<User> students = User.loadStudents();
-            render("Application/teacher.html", u, students);
-        }else{
-            render("Application/student.html", u);
+        
+        if (u = null){
+            flash.put("error", Messages.get("Public.login.error.credentials"));
+            login();
+        }
+        else {
+            if (u.getType().equals(Constants.User.TEACHER)){
+                List<User> students = User.loadStudents();
+                render("Application/teacher.html", u, students);
+             }else{
+             render("Application/student.html", u);
+            }
         }
     }
 


### PR DESCRIPTION
Evitar Login Sin poner usuario
Si no hay nada en user, da error y vuelve a login. En caso contrario comprueba si es profesor o alumno y realiza la accion correspondiente
